### PR TITLE
fix typo, add speaker series post and form

### DIFF
--- a/_posts/2025-07-29-speaker-series.markdown
+++ b/_posts/2025-07-29-speaker-series.markdown
@@ -1,0 +1,9 @@
+---
+layout: post
+title: "Submit a Talk Proposal"
+date: 2025-07-29
+---
+
+Interested in sharing your ideas or practicing your public speaking in front of a supportive audience? WGXC DC hosts regular lightning talks online and in-person, and we want to hear from you. [Please submit your talk proposal here!]({%link event-interest-form.markdown%}) Submissions are reviewed on a rolling basis. You may resubmit or submit multiple proposals at any time.
+
+Thanks for being a part of our community!

--- a/community.markdown
+++ b/community.markdown
@@ -4,7 +4,7 @@ title: Join Our Community
 permalink: /community/
 ---
 
-## [Meetup](https://www.meetup.com/women-and-gender-expansive-coders-dc-wgxc-dc/s)
+## [Meetup](https://www.meetup.com/women-and-gender-expansive-coders-dc-wgxc-dc/)
 
 Connect with women and non-binary members through our Meetup group, where you can RSVP and attend both virtual and in-person events, including technical talks, coding workshops, and networking sessions.
 

--- a/event-interest-form.markdown
+++ b/event-interest-form.markdown
@@ -1,0 +1,6 @@
+---
+layout: page
+permalink: event-interest-form.html
+---
+
+<iframe src="https://docs.google.com/forms/d/e/1FAIpQLSdt0fQGc0_9GApjQEbuNkfsE3wfqUVheiqxtleWHJ1AOUn_VQ/viewform?embedded=true" width="640" height="2573" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>


### PR DESCRIPTION
There was a typo in the meetup link :face_with_peeking_eye: sorry! I noticed it last week. 

The main part of this PR adds the event interest/speaker form. I embedded it on its own page, and then created a blog post linking to it. At some point, if we make the blog active, this post will fall off the front page, and then we'll have to make some layout decisions (do we add a permalink to it in the header? do we put it on the Community page??), but we don't need to think about that now.

To test this locally, you would need Ruby installed on your computer, and then you would need to pull this branch, run `bundle install` (first time setup) and then `bundle exec jekyll serve` to see the site running on port 4000.

If you cannot test it locally, here are some screenshots.

Homepage:
<img width="1557" height="1152" alt="image" src="https://github.com/user-attachments/assets/84eedd9c-cd25-4757-91b0-8fe967c2e217" />

Form page:
<img width="1550" height="1229" alt="image" src="https://github.com/user-attachments/assets/c06254f3-ae41-4a91-9b9e-1d340cdc60cf" />
(continues to scroll for the length of the form)
