### PR TITLE
move privacy policy and terms of use to footer only

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -30,6 +30,12 @@ github_username: wgxcodersdc
 
 author: Women and Gender eXpansive Coders DC
 
+# Header navigation - only these pages appear in header
+# Privacy policy and Terms of Use are in footer only
+header_pages:
+  - about.markdown
+  - community.markdown
+
 # Build settings
 theme: minima
 plugins:


### PR DESCRIPTION
## Summary
- Adds `header_pages` config to `_config.yml` to explicitly list pages shown in header navigation
- Privacy Policy and Terms of Use now appear only in the footer, reducing header clutter

## Test plan
- [ ] Verify header shows only: About, Join Our Community, Donate
- [ ] Verify footer still contains Privacy Policy and Terms of Use links
- [ ] Test on mobile responsive view

🤖 Generated with [Claude Code](https://claude.com/claude-code)