### PR TITLE
[WIP-DNMY]Test preview in ci push from branch

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -25,3 +25,4 @@ jobs:
                  with:
                       github_token: ${{ secrets.GITHUB_TOKEN }}
                       publish_dir: ./_site
+                      keep_files: true

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,46 @@
+name: PR Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+    branches: [main]
+
+# Only run for same-repo PRs (fork PRs have read-only GITHUB_TOKEN)
+# This condition is checked at the job level below
+
+concurrency: preview-${{ github.ref }}
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    # Skip PRs from forks — their GITHUB_TOKEN is read-only, so the job
+    # would fail trying to push to gh-pages or comment on the PR.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+
+    # Explicit permissions required by the preview action:
+    #   contents: write   — push the built site to the gh-pages branch
+    #   pull-requests: write — post/update the preview-link comment on the PR
+    # These are not granted by default in repos/orgs that use the
+    # restrictive default token permissions.
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        if: github.event.action != 'closed'
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.3.6
+          bundler-cache: true
+
+      - name: Build Jekyll site
+        if: github.event.action != 'closed'
+        run: bundle exec jekyll build --baseurl "/pr-preview/pr-${{ github.event.number }}"
+
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: _site/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -280,6 +280,12 @@ Each entry is a filename. The display text comes from the page's `title` in its 
 
 Pushes to `main` automatically build and deploy to GitHub Pages via the GitHub Actions workflow in `.github/workflows/jekyll.yml`.
 
+### Pull Request Previews
+
+When you open a pull request from a branch in this repository, a live preview of the site is automatically built and deployed. A comment will be posted on your PR with the preview URL (e.g., `https://wgxcodersdc.org/pr-preview/pr-17/`). The preview updates each time you push new commits to the PR branch and is cleaned up automatically when the PR is closed or merged.
+
+**Note for fork contributors:** Automatic previews are not available for PRs from forks due to GitHub token permissions. To preview your changes, run `bundle exec jekyll serve` locally (see [Getting Started](#getting-started)).
+
 ## Getting Help
 
 - **Jekyll docs:** [jekyllrb.com/docs](https://jekyllrb.com/docs/)


### PR DESCRIPTION
There were some hard-coded paths, that were breaking being able to render well the preview. Claude suggested using relative paths. 

Some of the changes needed to make this work: 

```txt

┌────────────────────────┬─────────────────────────────────────────────────────────────────────────────────┐                                              
  │          File          │                                       Fix                                       │                                              
  ├────────────────────────┼─────────────────────────────────────────────────────────────────────────────────┤                                              
  │ _layouts/homepage.html │ Logo src, event.image src, event-interest-form link, /blog/ link, /donate/ link │                                              
  ├────────────────────────┼─────────────────────────────────────────────────────────────────────────────────┤
  │ _layouts/donate.html   │ Logo src                                                                        │                                              
  ├────────────────────────┼─────────────────────────────────────────────────────────────────────────────────┤                                              
  │ _includes/header.html  │ Logo src                                                                        │
  ├────────────────────────┼─────────────────────────────────────────────────────────────────────────────────┤                                              
  │ _includes/footer.html  │ Root href="/", /donate/ link                                                    │                                              
  ├────────────────────────┼─────────────────────────────────────────────────────────────────────────────────┤                                              
  │ community.markdown     │ Event-interest-form link                                                        │
  └────────────────────────┴─────────────────────────────────────────────────────────────────────────────────┘
```

  Every hardcoded /path is now wrapped with {{ '...' | relative_url }}, so they'll respect baseurl in both production and previews. The data file paths in
  _data/event_highlights.yml are handled at the template level (the {{ event.image | relative_url }} fix in homepage.html), so they don't need to change.

 {{ '...' | relative_url }}                                                                                            
                                                                 
In Jekyll's Liquid templating language:                                                                                                                   
                                                                                                                                                            
  - {{ }} — outputs a value into the HTML                                                                                                                   
  - '...' — a string literal (the path you're providing)                                                                                                    
  - | — a pipe that passes the value on the left into a filter on the right                                                                                 
  - relative_url — a Jekyll filter that prepends site.baseurl to the path                                                                                   
                                                            
  So {{ '/blog/' | relative_url }} works like this:                                                                                                         
                                                            
  - When baseurl: "" (production): outputs /blog/
  - When baseurl: "/pr-preview/pr-17" (preview): outputs /pr-preview/pr-17/blog/

For the data file case, {{ event.image | relative_url }} does the same thing but reads the path from a variable instead of a string literal.

