### PR TITLE
Add PR preview in CI for easier review 

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -25,3 +25,4 @@ jobs:
                  with:
                       github_token: ${{ secrets.GITHUB_TOKEN }}
                       publish_dir: ./_site
+                      keep_files: true

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -25,4 +25,7 @@ jobs:
                  with:
                       github_token: ${{ secrets.GITHUB_TOKEN }}
                       publish_dir: ./_site
+                      # Preserve existing files on gh-pages (e.g. pr-preview/)
+                      # that aren't part of this build. Without this, the deploy
+                      # would wipe all PR preview subdirectories on every push to main.
                       keep_files: true

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,46 @@
+name: PR Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+    branches: [main]
+
+# Only run for same-repo PRs (fork PRs have read-only GITHUB_TOKEN)
+# This condition is checked at the job level below
+
+concurrency: preview-${{ github.ref }}
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    # Skip PRs from forks — their GITHUB_TOKEN is read-only, so the job
+    # would fail trying to push to gh-pages or comment on the PR.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+
+    # Explicit permissions required by the preview action:
+    #   contents: write   — push the built site to the gh-pages branch
+    #   pull-requests: write — post/update the preview-link comment on the PR
+    # These are not granted by default in repos/orgs that use the
+    # restrictive default token permissions.
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        if: github.event.action != 'closed'
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.3.6
+          bundler-cache: true
+
+      - name: Build Jekyll site
+        if: github.event.action != 'closed'
+        run: bundle exec jekyll build --baseurl "/pr-preview/pr-${{ github.event.number }}"
+
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: _site/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -282,6 +282,12 @@ Each entry is a filename. The display text comes from the page's `title` in its 
 
 Pushes to `main` automatically build and deploy to GitHub Pages via the GitHub Actions workflow in `.github/workflows/jekyll.yml`.
 
+### Pull Request Previews
+
+When you open a pull request from a branch in this repository, a live preview of the site is automatically built and deployed. A comment will be posted on your PR with the preview URL (e.g., `https://wgxcodersdc.org/pr-preview/pr-17/`). The preview updates each time you push new commits to the PR branch and is cleaned up automatically when the PR is closed or merged.
+
+**Note for fork contributors:** Automatic previews are not available for PRs from forks due to GitHub token permissions. To preview your changes, run `bundle exec jekyll serve` locally (see [Getting Started](#getting-started)).
+
 ## Getting Help
 
 - **Jekyll docs:** [jekyllrb.com/docs](https://jekyllrb.com/docs/)

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,7 +1,7 @@
 <link id="fa-stylesheet" rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@latest/css/all.min.css">
 
 <footer class="site-footer h-card">
-  <data class="u-url" href="/"></data>
+  <data class="u-url" href="{{ '/' | relative_url }}"></data>
 
   <div class="wrapper">
 
@@ -11,7 +11,7 @@
       <div class="footer-col footer-col-1">
         <ul class="contact-list">
           <li class="p-name">{{site.author}}</li><li><a class="u-email" href="mailto:{{site.email}}">{{site.email}}</a></li>
-          <li><a href="/donate/">Support Us</a></li>
+          <li><a href="{{ '/donate/' | relative_url }}">Support Us</a></li>
         </ul>
       </div>
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -2,7 +2,7 @@
 
   <div class="header wrapper">
     <div class="cell">
-    <a href="{{ "/" | relative_url }}"><img src="/logos/png/circles/174x174/wgxc_circle_color_white_background.png" class="header-logo" alt="WGXC logo" align="left"></a>
+    <a href="{{ "/" | relative_url }}"><img src="{{ '/logos/png/circles/174x174/wgxc_circle_color_white_background.png' | relative_url }}" class="header-logo" alt="WGXC logo" align="left"></a>
     </div>
     {%- assign default_paths = site.pages | map: "path" -%}
     {%- assign page_paths = site.header_pages | default: default_paths -%}

--- a/_layouts/donate.html
+++ b/_layouts/donate.html
@@ -5,7 +5,7 @@ layout: default
 <div class="prospectus">
 
   <section class="prospectus-hero">
-    <img src="/logos/png/circles/400x400/wgxc_circle_color_white_background.png" alt="WGXC DC logo" class="prospectus-logo">
+    <img src="{{ '/logos/png/circles/400x400/wgxc_circle_color_white_background.png' | relative_url }}" alt="WGXC DC logo" class="prospectus-logo">
     <h1>Women and Gender eXpansive Coders DC</h1>
     <p class="prospectus-tagline">Empowering women and non-binary technologists in the DC area</p>
   </section>

--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -6,7 +6,7 @@ layout: default
 <div class="homepage">
 
   <section class="home-hero">
-    <img src="/logos/png/circles/400x400/wgxc_circle_color_white_background.png" alt="WGXC DC logo" class="home-hero-logo">
+    <img src="{{ '/logos/png/circles/400x400/wgxc_circle_color_white_background.png' | relative_url }}" alt="WGXC DC logo" class="home-hero-logo">
     <h1>Code. Connect. Grow.</h1>
     <p class="home-hero-subtitle">A DC community where women and gender-expansive technologists build skills, careers, and friendships</p>
     <div class="home-hero-actions">
@@ -48,7 +48,7 @@ layout: default
     <div class="highlights">{% for event in site.data.event_highlights %}
       <div class="highlight-card">
         <div class="highlight-image highlight-image--{{ event.position }}">
-          <img src="{{ event.image }}"
+          <img src="{{ event.image | relative_url }}"
                alt="{{ event.image_alt }}"
                loading="lazy" width="{{ event.image_width }}" height="{{ event.image_height }}">
         </div>
@@ -75,8 +75,8 @@ layout: default
       {%- endif -%}
     </div>
     <div class="blog-feature-actions">
-      <a href="/event-interest-form.html" class="btn-secondary btn-small">Submit a Talk Proposal</a>
-      <a href="/blog/" class="blog-feature-more-link">View all posts &rarr;</a>
+      <a href="{{ '/event-interest-form.html' | relative_url }}" class="btn-secondary btn-small">Submit a Talk Proposal</a>
+      <a href="{{ '/blog/' | relative_url }}" class="blog-feature-more-link">View all posts &rarr;</a>
     </div>
   </section>
   {%- endif -%}
@@ -99,7 +99,7 @@ layout: default
     <p>WGXC Inc is a 501(c)(3) nonprofit. Your tax-deductible donation helps us keep events free and our community growing.</p>
     <div class="home-support-actions">
       <button zeffy-form-link="https://www.zeffy.com/embed/donation-form/kickstart-wgxc-dc?modal=true" class="btn-primary">Donate</button>
-      <a href="/donate/" class="home-support-learn-more">Learn more about how donations are used</a>
+      <a href="{{ '/donate/' | relative_url }}" class="home-support-learn-more">Learn more about how donations are used</a>
     </div>
   </section>
 

--- a/community.markdown
+++ b/community.markdown
@@ -32,7 +32,7 @@ Subscribe to the Women and Gender eXpansive Coders DC YouTube channel for past e
 
 Interested in sharing your ideas or practicing your public speaking in front of a supportive audience? We host regular lightning talks online and in-person and welcome speakers of all experience levels.
 
-<a href="/event-interest-form.html" class="btn-primary">Submit a Talk Proposal</a>
+<a href="{{ '/event-interest-form.html' | relative_url }}" class="btn-primary">Submit a Talk Proposal</a>
 
 ## Volunteer With Us
 


### PR DESCRIPTION
So this PR includes a generated preview of the site that is built based on the PR. That way it'll be easier to review in the future. It only works from branches PRs, if the PR comes from a fork, it skips the workflow because it's not possible to run it due to security (the GHA does not work, so to avoid the error we skip it directly. 

A maintainer will have to run from local. I added this into the CONTRIBUTING.md. 

- For some reason (I think it might be a DNS thing, but I'm not sure). Even though the action creates a `https` preview link, when opening, it shows as `http` and it says not secure, it's unclear why to me. 

- Note: There were some hard-coded paths, that were breaking being able to render well the preview. Claude suggested using relative paths, and that worked.  

Some of the changes needed to make this work: 

```txt

┌────────────────────────┬─────────────────────────────────────────────────────────────────────────────────┐                                              
  │          File          │                                       Fix                                       │                                              
  ├────────────────────────┼─────────────────────────────────────────────────────────────────────────────────┤                                              
  │ _layouts/homepage.html │ Logo src, event.image src, event-interest-form link, /blog/ link, /donate/ link │                                              
  ├────────────────────────┼─────────────────────────────────────────────────────────────────────────────────┤
  │ _layouts/donate.html   │ Logo src                                                                        │                                              
  ├────────────────────────┼─────────────────────────────────────────────────────────────────────────────────┤                                              
  │ _includes/header.html  │ Logo src                                                                        │
  ├────────────────────────┼─────────────────────────────────────────────────────────────────────────────────┤                                              
  │ _includes/footer.html  │ Root href="/", /donate/ link                                                    │                                              
  ├────────────────────────┼─────────────────────────────────────────────────────────────────────────────────┤                                              
  │ community.markdown     │ Event-interest-form link                                                        │
  └────────────────────────┴─────────────────────────────────────────────────────────────────────────────────┘
```

  Every hardcoded /path is now wrapped with {{ '...' | relative_url }}, so they'll respect baseurl in both production and previews. The data file paths in
  _data/event_highlights.yml are handled at the template level (the {{ event.image | relative_url }} fix in homepage.html), so they don't need to change.

 {{ '...' | relative_url }}                                                                                            
                                                                 
In Jekyll's Liquid templating language:                                                                                                                   
                                                                                                                                                            
  - {{ }} — outputs a value into the HTML                                                                                                                   
  - '...' — a string literal (the path you're providing)                                                                                                    
  - | — a pipe that passes the value on the left into a filter on the right                                                                                 
  - relative_url — a Jekyll filter that prepends site.baseurl to the path                                                                                   
                                                            
  So {{ '/blog/' | relative_url }} works like this:                                                                                                         
                                                            
  - When baseurl: "" (production): outputs /blog/
  - When baseurl: "/pr-preview/pr-17" (preview): outputs /pr-preview/pr-17/blog/

For the data file case, {{ event.image | relative_url }} does the same thing but reads the path from a variable instead of a string literal.
